### PR TITLE
Use cookbook to install libarchive

### DIFF
--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -14,13 +14,9 @@ def load_current_resource
 end
 
 action :extract do
-  package "libarchive12" do
-    action :nothing
-  end.run_action(:install)
-
-  package "libarchive-dev" do
-    action :nothing
-  end.run_action(:install)
+  recipe_eval do
+    run_context.include_recipe "libarchive"
+  end
 
   chef_gem "libarchive-ruby"
 


### PR DESCRIPTION
The cookbook wouldn't work on Ubunu 14.04 because libarchive12 isn't available, using the libarchive cookbook fixes the issue.